### PR TITLE
Updated download link for stable version of Instant Translate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,6 @@ All following commands must be pressed after modifier key "NVDA+Shift+t":
 ## Changes for 1.0 ##
 * Initial version.
 
-[1]: http://addons.nvda-project.org/files/get.php?file=it
+[1]: https://addons.nvda-project.org/files/get.php?file=instantTranslate
 
 [2]: http://addons.nvda-project.org/files/get.php?file=it-dev


### PR DESCRIPTION
Hi Beqa

You have recently provided a new version of this add-on, using a new ID as recommended for the add-on store. This results that download links are not valid anymore.
Thus people cannot find the add-on on the community website, nor from the internal documentation of the add-on. See [this thread](https://nvda.groups.io/g/nvda/topic/nvda_2023_1_and_instant/97947286?p=,,,100,0,0,0::recentpostdate/sticky,,,100,2,0,97947286,previd%3D1680176476479966778,nextid%3D1678902238806799020&previd=1680176476479966778&nextid=1678902238806799020) from NVDA mailing list.

I have already updated the download link of the website (commit 72971 on SVN screenreadertranslations repo).

This PR updates the link in the add-on's documentation.

I have updated only the link for the stable version since it is not clear to me what can be done with dev version, if you wish to use new dev or new beta channel or none of these.

If you want to release a new version with the updated documentation, do not forget to:
* wait until next Friday evening so that the link appears in the newly generated html files for all languages of the website
* merge the translations from nvdaaddons' fork so that you get the new version of the pages translated for the website

This way, you will ensure that the download link in the add-on's doc will be up-to-date, not only in English doc but also in all other translated docs.
