### PR TITLE
Remove warning

### DIFF
--- a/addon/globalPlugins/instantTranslate/interface.py
+++ b/addon/globalPlugins/instantTranslate/interface.py
@@ -14,7 +14,7 @@ from . import langslist as lngModule
 import addonHandler
 from copy import deepcopy
 from locale import strxfrm
-from donate_dialog import requestDonations
+from .donate_dialog import requestDonations
 
 addonHandler.initTranslation()
 

--- a/addon/globalPlugins/instantTranslate/interface.py
+++ b/addon/globalPlugins/instantTranslate/interface.py
@@ -18,7 +18,7 @@ from donate_dialog import requestDonations
 
 addonHandler.initTranslation()
 
-class InstantTranslateSettingsPanel(gui.SettingsPanel):
+class InstantTranslateSettingsPanel(gui.settingsDialogs.SettingsPanel):
 	# Translators: name of the dialog.
 	title = _("Instant Translate")
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,6 @@ All following commands must be pressed after modifier key "NVDA+Shift+t":
 ## Changes for 1.0 ##
 * Initial version.
 
-[1]: http://addons.nvda-project.org/files/get.php?file=it
+[1]: http://addons.nvda-project.org/files/get.php?file=instantTranslate
 
 [2]: http://addons.nvda-project.org/files/get.php?file=it-dev


### PR DESCRIPTION
### Issue
The following warning due to a deprecated usage of the SettingsPanel appears in the log at startup:
```
WARNING - gui.__getattr__ (10:25:17.495) - MainThread (14932):
Importing SettingsPanel from here is deprecated. Import SettingsPanel from gui.settingsDialogs instead. 
Stack trace:
  File "nvda.pyw", line 399, in <module>
  File "core.pyc", line 693, in main
  File "globalPluginHandler.pyc", line 30, in initialize
  File "globalPluginHandler.pyc", line 23, in listPlugins
  File "importlib\__init__.pyc", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\instantTranslate\globalPlugins\instantTranslate\__init__.py", line 11, in <module>
    from .interface import InstantTranslateSettingsPanel
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\instantTranslate\globalPlugins\instantTranslate\interface.py", line 21, in <module>
    class InstantTranslateSettingsPanel(gui.SettingsPanel):
  File "gui\__init__.pyc", line 115, in __getattr__
```

### Solution
Retrieve the panel's class from its module, not from gui.
